### PR TITLE
fix: eglGetPlatformDisplay dont work

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,11 @@
 qtwayland-opensource-src (5.15.7-1+dde) unstable; urgency=medium
 
+  [ Duan Ting ]
   * New upstream release (5.15.7).
+
+  [ Tang Haixiang ]
+  * client: Fix: eglGetPlatformDisplay dont work
+    -- fix-eglGetPlatformDisplay-dont-work.patch 
 
  -- Duan Ting <duanting@uniontech.com>  Mon, 14 Nov 2022 16:00:33 +0800
 

--- a/debian/patches/fix-eglGetPlatformDisplay-dont-work.patch
+++ b/debian/patches/fix-eglGetPlatformDisplay-dont-work.patch
@@ -1,0 +1,123 @@
+From: zhangjinqiang <zhangjinqiang@uniontech.com>
+Date: Sep 22, 2020 5:59pm GMT+0800
+Subject: Fix: eglGetPlatformDisplay dont work
+gitlab: https://gitlabwh.uniontech.com/wuhan/debian-patch/qt5.15/qtwayland-opensource-src/-/commit/d911112a05d56b5c6995ca8ee541022849c115b3?view=parallel
+
+---
+
+Index: qtwayland-opensource-src/qtwayland.pro
+===================================================================
+--- qtwayland-opensource-src.orig/qtwayland.pro
++++ qtwayland-opensource-src/qtwayland.pro
+@@ -1,3 +1,3 @@
+-requires(linux:!android|macos|qnx)
++requires(linux:!android|macos)
+ requires(qtHaveModule(gui))
+ load(qt_parts)
+Index: qtwayland-opensource-src/src/client/configure.json
+===================================================================
+--- qtwayland-opensource-src.orig/src/client/configure.json
++++ qtwayland-opensource-src/src/client/configure.json
+@@ -169,21 +169,6 @@
+                 ]
+             },
+             "use": "wayland-client"
+-        },
+-        "egl_1_5-wayland": {
+-            "label": "EGL 1.5 with Wayland Platform",
+-            "type": "compile",
+-            "test": {
+-                "include": [
+-                    "EGL/egl.h",
+-                    "EGL/eglext.h",
+-                    "wayland-client.h"
+-                ],
+-                "main": [
+-                    "eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, (struct wl_display *)(nullptr), nullptr);"
+-                ]
+-            },
+-            "use": "egl wayland-client"
+         }
+     },
+ 
+@@ -232,14 +217,9 @@
+             "condition": "features.wayland-client",
+             "output": [ "privateFeature" ]
+         },
+-        "egl-extension-platform-wayland": {
+-            "label": "EGL wayland platform extension",
+-            "condition": "features.wayland-client && features.opengl && features.egl && tests.egl_1_5-wayland",
+-            "output": [ "privateFeature" ]
+-        },
+         "wayland-egl": {
+             "label": "EGL",
+-            "condition": "features.wayland-client && features.opengl && features.egl && libs.wayland-egl && (!config.qnx || features.egl-extension-platform-wayland)",
++            "condition": "features.wayland-client && features.opengl && features.egl && libs.wayland-egl",
+             "output": [ "privateFeature" ]
+         },
+         "wayland-brcm": {
+@@ -259,7 +239,7 @@
+         },
+         "wayland-drm-egl-server-buffer": {
+             "label": "DRM EGL",
+-            "condition": "features.wayland-client && features.opengl && features.egl && tests.drm-egl-server && (!config.qnx || features.egl-extension-platform-wayland)",
++            "condition": "features.wayland-client && features.opengl && features.egl && tests.drm-egl-server",
+             "output": [ "privateFeature" ]
+         },
+         "wayland-libhybris-egl-server-buffer": {
+Index: qtwayland-opensource-src/src/hardwareintegration/client/drm-egl-server/drmeglserverbufferintegration.cpp
+===================================================================
+--- qtwayland-opensource-src.orig/src/hardwareintegration/client/drm-egl-server/drmeglserverbufferintegration.cpp
++++ qtwayland-opensource-src/src/hardwareintegration/client/drm-egl-server/drmeglserverbufferintegration.cpp
+@@ -125,11 +125,8 @@ void DrmEglServerBufferIntegration::init
+         return;
+     m_egl_initialized = true;
+ 
+-#if QT_CONFIG(egl_extension_platform_wayland)
+-    m_egl_display = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, m_display->wl_display(), nullptr);
+-#else
+     m_egl_display = eglGetDisplay((EGLNativeDisplayType) m_display->wl_display());
+-#endif
++
+     if (m_egl_display == EGL_NO_DISPLAY) {
+         qWarning("Failed to initialize drm egl server buffer integration. Could not get egl display from wl_display.");
+         return;
+Index: qtwayland-opensource-src/src/hardwareintegration/client/wayland-egl/qwaylandeglclientbufferintegration.cpp
+===================================================================
+--- qtwayland-opensource-src.orig/src/hardwareintegration/client/wayland-egl/qwaylandeglclientbufferintegration.cpp
++++ qtwayland-opensource-src/src/hardwareintegration/client/wayland-egl/qwaylandeglclientbufferintegration.cpp
+@@ -76,9 +76,6 @@ QWaylandEglClientBufferIntegration::~QWa
+ 
+ void QWaylandEglClientBufferIntegration::initialize(QWaylandDisplay *display)
+ {
+-#if QT_CONFIG(egl_extension_platform_wayland)
+-    m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, display->wl_display(), nullptr);
+-#else
+     if (q_hasEglExtension(EGL_NO_DISPLAY, "EGL_EXT_platform_base")) {
+         if (q_hasEglExtension(EGL_NO_DISPLAY, "EGL_KHR_platform_wayland") ||
+             q_hasEglExtension(EGL_NO_DISPLAY, "EGL_EXT_platform_wayland") ||
+@@ -101,7 +98,6 @@ void QWaylandEglClientBufferIntegration:
+ 
+         m_eglDisplay = eglGetDisplay((EGLNativeDisplayType) display->wl_display());
+     }
+-#endif
+ 
+     m_display = display;
+ 
+Index: qtwayland-opensource-src/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
+===================================================================
+--- qtwayland-opensource-src.orig/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
++++ qtwayland-opensource-src/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
+@@ -353,11 +353,8 @@ void QWaylandGLContext::updateGLFormat()
+ 
+     wl_surface *wlSurface = m_display->createSurface(nullptr);
+     wl_egl_window *eglWindow = wl_egl_window_create(wlSurface, 1, 1);
+-#if QT_CONFIG(egl_extension_platform_wayland)
+-    EGLSurface eglSurface = eglCreatePlatformWindowSurface(m_eglDisplay, m_config, eglWindow, nullptr);
+-#else
++    
+     EGLSurface eglSurface = eglCreateWindowSurface(m_eglDisplay, m_config, eglWindow, nullptr);
+-#endif
+ 
+     if (eglMakeCurrent(m_eglDisplay, eglSurface, eglSurface, m_context)) {
+         if (m_format.renderableType() == QSurfaceFormat::OpenGL

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -51,3 +51,4 @@ fix-when-refreshing-buffer-is-empty-cause-crash.patch
 fix-drag-icon-will-sink-during.patch
 fix-geometry-and-motion-conversion.patch
 fix-setFixedSize-window-size-abnoraml.patch
+fix-eglGetPlatformDisplay-dont-work.patch


### PR DESCRIPTION
Different graphics card drivers support different APIs, so EGL1.5 will not be detected when compiling. Avoid symbols not found on some platforms.

Bug: https://pms.uniontech.com/bug-view-126967.html

Log: Fix the problem that the desktop cannot be started on some platforms