### PR TITLE
Client: Avoid processing of events when showing windows

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 qtwayland-opensource-src (5.15.7.3-1+dde) UNRELEASED; urgency=medium
 
- -- Tang Haixiang <tanghaixiang@uniontech.com>  Thu, 22 Dec 2022 09:09:40 +0800
+  * Client: Avoid processing of events when showing windows
+    -- client-avoid-processing-of-events-when-showing-windows.patch
+
+ -- Tang Haixiang <tanghaixiang@uniontech.com>  Thu, 22 Dec 2022 09:12:24 +0800
 
 qtwayland-opensource-src (5.15.7.2-1+dde) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+qtwayland-opensource-src (5.15.7.3-1+dde) UNRELEASED; urgency=medium
+
+ -- Tang Haixiang <tanghaixiang@uniontech.com>  Thu, 22 Dec 2022 09:09:40 +0800
+
 qtwayland-opensource-src (5.15.7.2-1+dde) unstable; urgency=medium
 
   * Update symbols.

--- a/debian/patches/client-avoid-processing-of-events-when-showing-windows.patch
+++ b/debian/patches/client-avoid-processing-of-events-when-showing-windows.patch
@@ -1,0 +1,19 @@
+Author: Tang Haixiang <tanghaixiang@uniontech.com>
+Date:   Dec Wed 21 14:40:12 2022 +0800
+Subject: Client: Avoid processing of events when showing windows
+Upstream: https://codereview.qt-project.org/c/qt/qtwayland/+/381271
+
+---
+
+Index: qtwayland-opensource-src/src/client/qwaylandwindow.cpp
+===================================================================
+--- qtwayland-opensource-src.orig/src/client/qwaylandwindow.cpp
++++ qtwayland-opensource-src/src/client/qwaylandwindow.cpp
+@@ -447,7 +447,6 @@ void QWaylandWindow::setVisible(bool vis
+ 
+     if (visible) {
+         initWindow();
+-        mDisplay->flushRequests();
+ 
+         //setGeometry's parameter rect will be scaled if we pass QWindow's geometry
+         //so we need use toNativePixels scale QWindow's geometry

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -52,3 +52,4 @@ fix-drag-icon-will-sink-during.patch
 fix-geometry-and-motion-conversion.patch
 fix-setFixedSize-window-size-abnoraml.patch
 fix-eglGetPlatformDisplay-dont-work.patch
+client-avoid-processing-of-events-when-showing-windows.patch


### PR DESCRIPTION
    The only time we want to dispatch events from the wayland socket is when
    the application is waiting for external events. Doing so at any other
    time will cause unpredictable behavior in client code.
    
    This caused a crash downstream where we had outputs get altered whilst
    itterating through outputs, which shouldn't happen.
    
    There is no benefit to flushing here, it won't make anything appear
    faster as we haven't attached the buffer yet.
    
    Upstream: https://codereview.qt-project.org/c/qt/qtwayland/+/381271
    
    Bug: https://pms.uniontech.com/bug-view-150385.html
    
    Log: Fix some unexpected crashes
